### PR TITLE
Fix gateway connection

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,6 +17,10 @@ let package = Package(
     .target(
       name: "Swiftcord",
       dependencies: [.product(name: "WebSocketKit", package: "websocket-kit"), "Rainbow"]
+    ),
+    .testTarget(
+        name: "SwiftcordTests",
+        dependencies: [.target(name: "Swiftcord")]
     )
   ]
 )

--- a/Sources/Swiftcord/Gateway/Gateway.swift
+++ b/Sources/Swiftcord/Gateway/Gateway.swift
@@ -15,6 +15,7 @@ import Dispatch
 import WebSocketKit
 import NIOPosix
 import NIOWebSocket
+import NIO
 
 protocol Gateway: AnyObject {
 
@@ -50,19 +51,20 @@ extension Gateway {
   
   /// Starts the gateway connection
   func start() {
-      let loopgroup = MultiThreadedEventLoopGroup(numberOfThreads: 4)
+      let loopgroup = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
       
       self.acksMissed = 0
       
       let url = URL(string: self.gatewayUrl)!
+      let path = self.gatewayUrl.components(separatedBy: "/?")[1]
       
       let wsClient = WebSocketClient(eventLoopGroupProvider: .shared(loopgroup.next()), configuration: .init(tlsConfiguration: .clientDefault, maxFrameSize: 1 << 31))
-      
       
       wsClient.connect(
         scheme: url.scheme!,
         host: url.host!,
-        port: url.port ?? 443
+        port: url.port ?? 443,
+        path: "/?" + path
       ) { ws in
           
           self.session = ws

--- a/Sources/Swiftcord/Shield/Shield.swift
+++ b/Sources/Swiftcord/Shield/Shield.swift
@@ -38,10 +38,6 @@ open class Shield: Swiftcord {
 
     super.init(token: token, options: swiftcordOptions)
 
-    if self.shieldOptions.willDefaultHelp {
-      self.registerHelp()
-    }
-
     self.on(.ready) { [unowned self] data in
       let bot = data as! User
 
@@ -230,24 +226,6 @@ open class Shield: Swiftcord {
       for alias in options.aliases {
         self.commandAliases[alias.lowercased()] = (alias, commandName.lowercased())
       }
-    }
-  }
-
-  /// Creates a default help command for the bot
-  func registerHelp() {
-    self.register("help") { [unowned self] msg, _ in
-      var embed = Embed()
-      embed.title = "\(self.user!.username!)'s Help"
-
-      for command in self.commands.values {
-        embed.addField(
-          command.name,
-          value: command.options.description,
-          isInline: true
-        )
-      }
-
-      msg.channel.send(embed)
     }
   }
 

--- a/Sources/Swiftcord/Sword.swift
+++ b/Sources/Swiftcord/Sword.swift
@@ -2114,13 +2114,15 @@ open class Swiftcord: Eventable {
    - parameter channelId: Channel to send message to
    */
   public func send(
-    _ content: Embed,
+    _ embeds: EmbedBuilder...,
     to channelId: Snowflake,
     then completion: ((Message?, RequestError?) -> Void)? = nil
   ) {
-    self.request(
+      let jsonData = try! self.encoder.encode(EmbedBody(embeds: embeds))
+      
+    self.requestWithBodyAsData(
       .createMessage(channelId),
-      body: ["embed": content.encode()]
+      body: jsonData
     ) { [unowned self] data, error in
       if let error = error {
         completion?(nil, error)

--- a/Sources/Swiftcord/Types/Channel.swift
+++ b/Sources/Swiftcord/Types/Channel.swift
@@ -232,7 +232,7 @@ public extension TextChannel {
    - parameter message: Embed to send as message
    */
   func send(
-    _ message: Embed,
+    _ message: EmbedBuilder,
     then completion: ((Message?, RequestError?) -> Void)? = nil
   ) {
     self.swiftcord?.send(message, to: self.id, then: completion)

--- a/Sources/Swiftcord/Types/EmbedBuilder.swift
+++ b/Sources/Swiftcord/Types/EmbedBuilder.swift
@@ -9,37 +9,40 @@ import Foundation
 
 public class EmbedBuilder: Encodable {
     /// Author dictionary from embed
-    public var author: Author?
+    var author: Author?
   
     /// Side panel color of embed
-    public var color: Int?
+    var color: Int?
   
     /// Description of the embed
-    public var description: String?
+    var description: String?
   
     /// Fields for the embed
-    public var fields: [Field]?
+    var fields: [Field]?
   
     /// Footer dictionary from embed
-    public var footer: Footer?
+    var footer: Footer?
   
     /// Image data from embed
-    public var image: Image?
+    var image: Image?
     
     /// Thumbnail data from embed
-    public var thumbnail: Thumbnail?
+    var thumbnail: Thumbnail?
+    
+    /// Timestamp of the embed
+    var timestamp: String?
   
     /// Title of the embed
-    public var title: String?
+    var title: String?
   
     /// Type of embed | Discord says this should be considered deprecated. As such we set as rich
-    public var type: String
+    var type: String
   
     /// URL of the embed
-    public var url: String?
+    var url: String?
   
     /// Video data from embed
-    public var video: Video?
+    var video: Video?
     
     // MARK: Initializers
     
@@ -54,7 +57,7 @@ public class EmbedBuilder: Encodable {
     /**
      Adds a field to the embed
      
-     - parameter name: Name to give field
+     - parameter name: Title of the field
      - parameter value: Text that will be displayed underneath name
      - parameter inline: Whether or not to keep this field inline with others
     */
@@ -137,6 +140,11 @@ public class EmbedBuilder: Encodable {
         
         return self
     }
+    
+    public func setTimestamp() -> Self {
+        self.timestamp = ISO8601DateFormatter().string(from: Date())
+        return self
+    }
 }
 
 extension EmbedBuilder {
@@ -212,4 +220,9 @@ extension EmbedBuilder {
             self.width = width
         }
     }
+}
+
+/// Represents the parent tag in the JSON we send to Discord with an `EmbedBuilder`
+struct EmbedBody: Encodable {
+    let embeds: [EmbedBuilder]
 }

--- a/Sources/Swiftcord/Types/Guild.swift
+++ b/Sources/Swiftcord/Types/Guild.swift
@@ -139,6 +139,7 @@ public class Guild: Updatable, Imageable {
                 for thread in threads {
                     let channel = Thread(swiftcord, thread)
                     self.threads[channel.id] = channel
+                    self.channels[channel.id] = channel
                 }
             }
 

--- a/Sources/Swiftcord/Types/GuildText.swift
+++ b/Sources/Swiftcord/Types/GuildText.swift
@@ -213,13 +213,13 @@ public struct Overwrite {
   */
   init(_ json: [String: Any]) {
 
-    self.allow = json["allow"] as! Int
-    self.deny = json["deny"] as! Int
+    self.allow = Int(json["allow"] as! String)!
+    self.deny = Int(json["deny"] as! String)!
     self.id = Snowflake(json["id"])!
-    self.type = OverwriteType(rawValue: json["type"] as! String)!
+    self.type = OverwriteType(rawValue: json["type"] as! Int)!
   }
     
-    public enum OverwriteType: String {
+    public enum OverwriteType: Int {
         case role
         case member
     }

--- a/Sources/Swiftcord/Types/Message.swift
+++ b/Sources/Swiftcord/Types/Message.swift
@@ -272,7 +272,7 @@ public struct Message {
    - parameter message: Embed to send to channel
   */
   public func reply(
-    with message: Embed,
+    with message: EmbedBuilder,
     then completion: ((Message?, RequestError?) -> Void)? = nil
   ) {
     self.channel.send(message, then: completion)

--- a/Sources/Swiftcord/Types/Role.swift
+++ b/Sources/Swiftcord/Types/Role.swift
@@ -49,7 +49,7 @@ public struct Role: Codable {
     self.isManaged = json["managed"] as! Bool
     self.isMentionable = json["mentionable"] as! Bool
     self.name = json["name"] as! String
-    self.permissions = json["permissions"] as! Int
+    self.permissions = Int(json["permissions"] as! String)!
     self.position = json["position"] as! Int
   }
 

--- a/Tests/SwiftcordTests/SwiftcordTests.swift
+++ b/Tests/SwiftcordTests/SwiftcordTests.swift
@@ -1,0 +1,56 @@
+@testable import Swiftcord
+import XCTest
+
+final class SwiftCordTests: XCTestCase {
+    /// Sets up the `Swiftcord` object needed across functions
+    func setUpBot() -> Swiftcord {
+        let bot = Swiftcord(token: "")
+        bot.setIntents(intents: .guilds, .guildMessages)
+        
+        let activity = Activities(name: "WiiLink Championships", type: .competing)
+
+        bot.editStatus(status: .online, activity: activity)
+        return bot
+    }
+    
+    func testStartBot() {
+        let bot = self.setUpBot()
+        
+        bot.connect()
+    }
+    
+    func testMessageCommand() {
+        let bot = self.setUpBot()
+        
+        bot.on(.messageCreate) { data in
+            let msg = data as! Message
+            
+            if msg.content == "+test" {
+                msg.reply(with: "Testing Swiftcord!")
+            }
+        }
+        
+        bot.connect()
+    }
+    
+    func testSendEmbed() {
+        let bot = self.setUpBot()
+        
+        bot.on(.messageCreate) { data in
+            let msg = data as! Message
+            
+            if msg.content == "+test" {
+                let embed = EmbedBuilder()
+                    .setTitle(title: "Swiftcord Embed")
+                    .setDescription(description: "This embed shows off the embed")
+                    .addField("Field", value: "A field")
+                    .setFooter(text: "Created in Swiftcord")
+                    .setTimestamp()
+                
+                msg.reply(with: embed)
+            }
+        }
+        
+        bot.connect()
+    }
+}


### PR DESCRIPTION
I wouldn't have made this PR, but it is very important. So I didn't realize that `url.path` didn't include the params needed to connect to the proper API version. As such, it was actually on gateway v6. This PR fixes it and uses `EmbedBuilder` for sending embeds.