### PR TITLE
Always use `guilds` intent

### DIFF
--- a/Sources/Swiftcord/Gateway/EventHandler.swift
+++ b/Sources/Swiftcord/Gateway/EventHandler.swift
@@ -349,16 +349,16 @@ extension Shard {
       self.swiftcord.emit(event, with: (channel, userID, messageID, emoji))
         
     case .threadCreate:
-        let thread = Thread(swiftcord, data)
+        let thread = ThreadChannel(swiftcord, data)
         self.swiftcord.emit(.threadCreate, with: thread)
         
     case .threadDelete:
-        let thread = Thread(swiftcord, data)
+        let thread = ThreadChannel(swiftcord, data)
         self.swiftcord.emit(.threadDelete, with: thread)
         
     
     case .threadUpdate:
-        let thread = Thread(swiftcord, data)
+        let thread = ThreadChannel(swiftcord, data)
         self.swiftcord.emit(.threadUpdate, with: thread)
 
     /// TYPING_START

--- a/Sources/Swiftcord/Sword.swift
+++ b/Sources/Swiftcord/Sword.swift
@@ -31,7 +31,7 @@ open class Swiftcord: Eventable {
   var isGloballyLocked = false
     
     /// Intents the bot is entitled to
-    var intents = 0
+    var intents = 1
     
     /// Array of the intents the bot is entitled to
     var intentArray: [Intents] = []

--- a/Sources/Swiftcord/Types/AuditLog.swift
+++ b/Sources/Swiftcord/Types/AuditLog.swift
@@ -17,7 +17,7 @@ public struct AuditLog {
     public var guildScheduledEvents = [ScheduledEvent]()
     
     /// Array of threads found in audit log
-    public var threads = [Thread]()
+    public var threads = [ThreadChannel]()
 
     /// Array of users found in audit log
     public var users = [User]()
@@ -46,7 +46,7 @@ public struct AuditLog {
         
         let threads = json["threads"]!
         for thread in threads {
-            self.threads.append(Thread(swiftcord, thread as! [String : Any]))
+            self.threads.append(ThreadChannel(swiftcord, thread as! [String : Any]))
         }
 
         let users = json["users"]!

--- a/Sources/Swiftcord/Types/Guild.swift
+++ b/Sources/Swiftcord/Types/Guild.swift
@@ -137,7 +137,7 @@ public class Guild: Updatable, Imageable {
         
             if let threads = json["threads"] as? [[String : Any]] {
                 for thread in threads {
-                    let channel = Thread(swiftcord, thread)
+                    let channel = ThreadChannel(swiftcord, thread)
                     self.threads[channel.id] = channel
                     self.channels[channel.id] = channel
                 }

--- a/Sources/Swiftcord/Types/Thread.swift
+++ b/Sources/Swiftcord/Types/Thread.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public class Thread: TextChannel, GuildChannel, Updatable {
+public class ThreadChannel: TextChannel, GuildChannel, Updatable {
     // MARK: Properties
 
     /// Parent class

--- a/Sources/Swiftcord/Utils/Enums.swift
+++ b/Sources/Swiftcord/Utils/Enums.swift
@@ -660,7 +660,8 @@ public enum Event: String {
 
 /// Value for Intents
 public enum Intents: Int {
-    case guilds = 1
+    /// The `guilds` intent is required for us to cache channels locally. It is also needed for many events
+    // case guilds = 1
     
     /// Events on member join, leave and updates. This is a Privileged Intent
     case guildMembers = 2

--- a/Sources/Swiftcord/Utils/Enums.swift
+++ b/Sources/Swiftcord/Utils/Enums.swift
@@ -499,7 +499,7 @@ public enum Event: String {
      ### Usage ###
      ```swift
      bot.on(.threadCreate) { data in
-       let thread = data as! Thread
+       let thread = data as! ThreadChannel
      }
      ```
     */
@@ -511,7 +511,7 @@ public enum Event: String {
      ### Usage ###
      ```swift
      bot.on(.threadDelete) { data in
-       let thread = data as! Thread
+       let thread = data as! ThreadChannel
      }
      ```
     */
@@ -523,7 +523,7 @@ public enum Event: String {
      ### Usage ###
      ```swift
      bot.on(.threadUpdate) { data in
-       let thread = data as! Thread
+       let thread = data as! ThreadChannel
      }
      ```
     */


### PR DESCRIPTION
We need the `guilds` intent for caching. If the user doesn't include this intent, many functions are rendered useless. As such we will force the intent.