### PR TITLE
Add getApplicationCommands() methods, move towards Codable in request()

### DIFF
--- a/Sources/Swiftcord/Rest/EndpointInfo.swift
+++ b/Sources/Swiftcord/Rest/EndpointInfo.swift
@@ -145,12 +145,12 @@ extension Endpoint {
 
         case .getCurrentUserGuilds:
             return (.get, "/users/@me/guilds")
-            
-		case let .getGlobalSlashCommands(applicationId):
-			return (.get, "/applications/\(applicationId)/commands")
+
+        case let .getGlobalSlashCommands(applicationId):
+            return (.get, "/applications/\(applicationId)/commands")
 			
-		case let .getGuildSlashCommands(applicationId, guildId):
-			return (.get, "/applications/\(applicationId)/guilds/\(guildId)/commands")
+        case let .getGuildSlashCommands(applicationId, guildId):
+            return (.get, "/applications/\(applicationId)/guilds/\(guildId)/commands")
 
         case let .getGuild(guild):
             return (.get, "/guilds/\(guild)")

--- a/Sources/Swiftcord/Rest/EndpointInfo.swift
+++ b/Sources/Swiftcord/Rest/EndpointInfo.swift
@@ -145,6 +145,12 @@ extension Endpoint {
 
         case .getCurrentUserGuilds:
             return (.get, "/users/@me/guilds")
+            
+		case let .getGlobalSlashCommands(applicationId):
+			return (.get, "/applications/\(applicationId)/commands")
+			
+		case let .getGuildSlashCommands(applicationId, guildId):
+			return (.get, "/applications/\(applicationId)/guilds/\(guildId)/commands")
 
         case let .getGuild(guild):
             return (.get, "/guilds/\(guild)")

--- a/Sources/Swiftcord/Rest/Endpoints.swift
+++ b/Sources/Swiftcord/Rest/Endpoints.swift
@@ -91,6 +91,10 @@ enum Endpoint {
     case getCurrentUser
 
     case getCurrentUserGuilds
+    
+    case getGlobalSlashCommands(Snowflake)
+    
+    case getGuildSlashCommands(Snowflake, Snowflake)
 
     case getGuild(Snowflake)
 

--- a/Sources/Swiftcord/Rest/Endpoints.swift
+++ b/Sources/Swiftcord/Rest/Endpoints.swift
@@ -91,7 +91,7 @@ enum Endpoint {
     case getCurrentUser
 
     case getCurrentUserGuilds
-    
+
     case getGlobalSlashCommands(Snowflake)
     
     case getGuildSlashCommands(Snowflake, Snowflake)

--- a/Sources/Swiftcord/Rest/Request.swift
+++ b/Sources/Swiftcord/Rest/Request.swift
@@ -306,10 +306,10 @@ extension Swiftcord {
             return
           }
 
-			let returnedData: Any?;
+			let returnedData: Any?
           
-			if (returnJSONData) {
-				returnedData = data;
+			if returnJSONData {
+				returnedData = data
 			} else {
 				returnedData = try? JSONSerialization.jsonObject(
 					with: data!,
@@ -454,10 +454,10 @@ extension Swiftcord {
             return
           }
 
-          let returnedData: Any?;
+          let returnedData: Any?
           
-			if (returnJSONData) {
-				returnedData = data;
+			if returnJSONData {
+				returnedData = data
 			} else {
 				returnedData = try? JSONSerialization.jsonObject(
 					with: data!,

--- a/Sources/Swiftcord/Rest/Request.swift
+++ b/Sources/Swiftcord/Rest/Request.swift
@@ -25,6 +25,7 @@ extension Swiftcord {
      - parameter authorization: Whether or not the Authorization header is required by Discord
      - parameter method: Type of HTTP Method
      - parameter rateLimited: Whether or not the HTTP request needs to be rate limited
+     - parameter returnJSONData: If true, data returned is raw JSON data, rather than JSONSerialization of JSON string
      - parameter reason: Optional for when user wants to specify audit-log reason
      */
     func request(
@@ -34,6 +35,7 @@ extension Swiftcord {
         files: [AttachmentBuilder]? = nil,
         authorization: Bool = true,
         rateLimited: Bool = true,
+        returnJSONData: Bool = false,
         reason: String? = nil
     ) async throws -> Any? {
         let endpointInfo = endpoint.httpInfo
@@ -124,15 +126,14 @@ extension Swiftcord {
                 files: files,
                 authorization: authorization,
                 rateLimited: rateLimited,
-                reason: reason
+                reason: reason,
+                returnJSONData: returnJSONData
             ) { data, err in
                 if let err = err {
                     continuation.resume(throwing: err)
-                }
-
-                if data != nil {
-                    continuation.resume(returning: data)
-                }
+                } else {
+					continuation.resume(returning: data)
+				}
             }
         })
 
@@ -149,6 +150,7 @@ extension Swiftcord {
      - parameter authorization: Whether or not the Authorization header is required by Discord
      - parameter method: Type of HTTP Method
      - parameter rateLimited: Whether or not the HTTP request needs to be rate limited
+     - parameter returnJSONData: If true, data returned is raw JSON data, rather than JSONSerialization of JSON string
      - parameter reason: Optional for when user wants to specify audit-log reason
      */
     func requestWithBodyAsData(
@@ -158,6 +160,7 @@ extension Swiftcord {
         files: [AttachmentBuilder]? = nil,
         authorization: Bool = true,
         rateLimited: Bool = true,
+        returnJSONData: Bool = false,
         reason: String? = nil
     ) async throws -> Any? {
         let endpointInfo = endpoint.httpInfo
@@ -236,7 +239,8 @@ extension Swiftcord {
                 files: files,
                 authorization: authorization,
                 rateLimited: rateLimited,
-                reason: reason
+                reason: reason,
+                returnJSONData: returnJSONData                
             ) { data, err in
                 if let err = err {
                     continuation.resume(throwing: err)
@@ -260,6 +264,7 @@ extension Swiftcord {
         authorization: Bool = true,
         rateLimited: Bool = true,
         reason: String? = nil,
+        returnJSONData: Bool = false,
         completion: @escaping (Any?, ResponseError?) -> Void
     ) {
         let sema = DispatchSemaphore(value: 0)
@@ -301,11 +306,16 @@ extension Swiftcord {
             return
           }
 
-          let returnedData = try? JSONSerialization.jsonObject(
-            with: data!,
-            options: .allowFragments
-          )
-
+			let returnedData: Any?;
+          
+			if (returnJSONData) {
+				returnedData = data;
+			} else {
+				returnedData = try? JSONSerialization.jsonObject(
+					with: data!,
+					options: .allowFragments
+				)
+			}
           if response.statusCode != 200 && response.statusCode != 201 {
 
             if response.statusCode == 429 {
@@ -335,7 +345,8 @@ extension Swiftcord {
                         body: body,
                         files: files,
                         authorization: authorization,
-                        rateLimited: rateLimited
+                        rateLimited: rateLimited,
+                        returnJSONData: returnJSONData
                       )
                   }
               }
@@ -351,7 +362,8 @@ extension Swiftcord {
                         body: body,
                         files: files,
                         authorization: authorization,
-                        rateLimited: rateLimited
+                        rateLimited: rateLimited,
+                        returnJSONData: returnJSONData
                       )
                   }
               }
@@ -406,6 +418,7 @@ extension Swiftcord {
         authorization: Bool = true,
         rateLimited: Bool = true,
         reason: String? = nil,
+        returnJSONData: Bool = false,
         completion: @escaping (Any?, ResponseError?) -> Void
     ) {
         let sema = DispatchSemaphore(value: 0)
@@ -441,10 +454,16 @@ extension Swiftcord {
             return
           }
 
-          let returnedData = try? JSONSerialization.jsonObject(
-            with: data!,
-            options: .allowFragments
-          )
+          let returnedData: Any?;
+          
+			if (returnJSONData) {
+				returnedData = data;
+			} else {
+				returnedData = try? JSONSerialization.jsonObject(
+					with: data!,
+					options: .allowFragments
+				)
+			}
 
           if response.statusCode != 200 && response.statusCode != 201 {
 
@@ -475,7 +494,8 @@ extension Swiftcord {
                         body: body,
                         files: files,
                         authorization: authorization,
-                        rateLimited: rateLimited
+                        rateLimited: rateLimited,
+                        returnJSONData: returnJSONData
                       )
                   }
               }
@@ -491,7 +511,8 @@ extension Swiftcord {
                         body: body,
                         files: files,
                         authorization: authorization,
-                        rateLimited: rateLimited
+                        rateLimited: rateLimited,
+                        returnJSONData: returnJSONData
                       )
                   }
               }

--- a/Sources/Swiftcord/Swiftcord.swift
+++ b/Sources/Swiftcord/Swiftcord.swift
@@ -55,7 +55,7 @@ open class Swiftcord {
     /// Global JSONEncoder
     var encoder = JSONEncoder()
     
-    var decoder = JSONDecoder();
+    var decoder = JSONDecoder()
 
     /// Event listeners with the `ListenerAdapter` class
     public var listenerAdaptors = [ListenerAdapter]()
@@ -1837,16 +1837,13 @@ open class Swiftcord {
     ) async throws {
         _ = try await self.request(.deleteGlobalSlashCommand(self.user!.id, commandId))
     }
-    
-    public func getApplicationCommands() async throws -> [ApplicationCommand]
-    {
+
+    public func getApplicationCommands() async throws -> [ApplicationCommand] {
 		if let appCommandResponse = try await self.request(.getGlobalSlashCommands(self.user!.id), returnJSONData: true) as? Data {
-			return try self.decoder.decode([ApplicationCommand].self, from: appCommandResponse);
+			return try self.decoder.decode([ApplicationCommand].self, from: appCommandResponse)
 		} else {
-			self.log("Request response was not Data when trying to get application commands.");
-			return [];
+			self.log("Request response was not Data when trying to get application commands.")
+			return []
 		}
     }
-    
-    
 }

--- a/Sources/Swiftcord/Swiftcord.swift
+++ b/Sources/Swiftcord/Swiftcord.swift
@@ -54,6 +54,8 @@ open class Swiftcord {
 
     /// Global JSONEncoder
     var encoder = JSONEncoder()
+    
+    var decoder = JSONDecoder();
 
     /// Event listeners with the `ListenerAdapter` class
     public var listenerAdaptors = [ListenerAdapter]()
@@ -1835,4 +1837,16 @@ open class Swiftcord {
     ) async throws {
         _ = try await self.request(.deleteGlobalSlashCommand(self.user!.id, commandId))
     }
+    
+    public func getApplicationCommands() async throws -> [ApplicationCommand]
+    {
+		if let appCommandResponse = try await self.request(.getGlobalSlashCommands(self.user!.id), returnJSONData: true) as? Data {
+			return try self.decoder.decode([ApplicationCommand].self, from: appCommandResponse);
+		} else {
+			self.log("Request response was not Data when trying to get application commands.");
+			return [];
+		}
+    }
+    
+    
 }

--- a/Sources/Swiftcord/Types/Guild.swift
+++ b/Sources/Swiftcord/Types/Guild.swift
@@ -820,14 +820,13 @@ public class Guild: Updatable, Imageable {
     ) async throws {
         _ = try await self.swiftcord?.request(.deleteGuildApplicationCommand(self.swiftcord!.user!.id, self.id, commandId))
     }
-    
-    public func getApplicationCommands() async throws -> [ApplicationCommand]
-    {
+
+    public func getApplicationCommands() async throws -> [ApplicationCommand] {
 		if let appCommandResponse = try await self.swiftcord!.request(.getGuildSlashCommands(self.swiftcord!.user!.id, self.id), returnJSONData: true) as? Data {
-			return try self.swiftcord!.decoder.decode([ApplicationCommand].self, from: appCommandResponse);
+			return try self.swiftcord!.decoder.decode([ApplicationCommand].self, from: appCommandResponse)
 		} else {
-			self.swiftcord!.log("Request response was not Data when trying to get application commands.");
-			return [];
+			self.swiftcord!.log("Request response was not Data when trying to get application commands.")
+			return []
 		}
     }
 }

--- a/Sources/Swiftcord/Types/Guild.swift
+++ b/Sources/Swiftcord/Types/Guild.swift
@@ -820,6 +820,16 @@ public class Guild: Updatable, Imageable {
     ) async throws {
         _ = try await self.swiftcord?.request(.deleteGuildApplicationCommand(self.swiftcord!.user!.id, self.id, commandId))
     }
+    
+    public func getApplicationCommands() async throws -> [ApplicationCommand]
+    {
+		if let appCommandResponse = try await self.swiftcord!.request(.getGuildSlashCommands(self.swiftcord!.user!.id, self.id), returnJSONData: true) as? Data {
+			return try self.swiftcord!.decoder.decode([ApplicationCommand].self, from: appCommandResponse);
+		} else {
+			self.swiftcord!.log("Request response was not Data when trying to get application commands.");
+			return [];
+		}
+    }
 }
 
 extension Guild {

--- a/Sources/Swiftcord/Types/Interactions/ApplicationCommands.swift
+++ b/Sources/Swiftcord/Types/Interactions/ApplicationCommands.swift
@@ -34,9 +34,9 @@ public struct ApplicationCommand: Decodable {
 	public let application_id: Snowflake
 	public let guild_id: Snowflake?
 	public let name: String
-	public let name_localizations: [String:String]?
+	public let name_localizations: [String: String]?
 	public let description: String
-	public let description_localizations: [String:String]?
+	public let description_localizations: [String: String]?
 	public let options: [ApplicationCommandOptions]?
 	public let default_member_permissions: String?
 	public let dm_permission: Bool?
@@ -87,7 +87,7 @@ public class ApplicationCommandOptions: Codable {
 public struct ApplicationChoices: Codable {
     public let name: String
     public let value: String
-    
+
     public init(name: String, value: String) {
         self.name = name
         self.value = value

--- a/Sources/Swiftcord/Types/Interactions/ApplicationCommands.swift
+++ b/Sources/Swiftcord/Types/Interactions/ApplicationCommands.swift
@@ -7,11 +7,11 @@
 
 import Foundation
 
-public enum ApplicationType: Int, Encodable {
+public enum ApplicationType: Int, Codable {
     case slashCommand = 1, userCommand, messageCommand
 }
 
-public enum ApplicationCommandType: Int, Encodable {
+public enum ApplicationCommandType: Int, Codable {
     case subCommand = 1, subCommandGroup, string, int, bool, user, channel, role, mentionable, number, attatchment
 }
 
@@ -24,13 +24,33 @@ public enum InteractionCallbackType: Int, Encodable {
     case modal = 9
 }
 
+
+/// Existing ApplicationCommands, retrieved with GetApplicationCommands().
+/// This does not allow you to change existing commands, but merely inspect them.
+/// Localization is untested currently.
+public struct ApplicationCommand: Decodable {
+	public let id: Snowflake
+	public let type: ApplicationCommandType
+	public let application_id: Snowflake
+	public let guild_id: Snowflake?
+	public let name: String
+	public let name_localizations: [String:String]?
+	public let description: String
+	public let description_localizations: [String:String]?
+	public let options: [ApplicationCommandOptions]?
+	public let default_member_permissions: String?
+	public let dm_permission: Bool?
+	public let default_permission: Bool?
+	public let version: Snowflake
+}
+
 /// Options for Application commands
-public class ApplicationCommandOptions: Encodable {
+public class ApplicationCommandOptions: Codable {
     public var type: ApplicationCommandType
     public var name: String
     public var description: String
-    public var required: Bool
-    public var choices: [ApplicationChoices]
+    public var required: Bool?
+    public var choices: [ApplicationChoices]?
     // TODO: Subcommands
     public var channelTypes: Int?
     public var autoComplete: Bool?
@@ -46,13 +66,13 @@ public class ApplicationCommandOptions: Encodable {
     }
 
     public func addChoice(name: String, value: String) -> Self {
-        self.choices.append(ApplicationChoices(name: name, value: value))
+        self.choices!.append(ApplicationChoices(name: name, value: value)) // Force-unwrap since if we're adding choices then this should have been made with init(), not decoded.
 
         return self
     }
 
     public func addChoices(choices: ApplicationChoices...) -> Self {
-        self.choices += choices
+        self.choices! += choices // Force-unwrap since if we're adding choices then this should have been made with init(), not decoded.
 
         return self
     }
@@ -64,7 +84,7 @@ public class ApplicationCommandOptions: Encodable {
     }
 }
 
-public struct ApplicationChoices: Encodable {
+public struct ApplicationChoices: Codable {
     public let name: String
     public let value: String
     

--- a/Sources/Swiftcord/Types/Snowflake.swift
+++ b/Sources/Swiftcord/Types/Snowflake.swift
@@ -35,6 +35,28 @@ public struct Snowflake: Codable {
     public var workerId: Int {
         return Int((rawValue & 0x3E0000) >> 17)
     }
+    
+	
+	/// Need to implement out own decoder, since the Snowflake IDs come in as Strings from the API. Also check for UInt64 just to be complete.
+	/// Sets the rawValue to 0 in the event the string value can't be made into a UInt64.
+	/// - Parameter decoder: The dcoder to decode with.
+	public init(from decoder: Decoder) throws {
+		let container = try decoder.singleValueContainer()
+		
+		if let idString = try? container.decode(String.self) {
+			if let intVal = UInt64(idString) {
+				self.rawValue = intVal;
+			} else {
+				self.rawValue = 0;
+			}
+		} else {
+			if let idInt = try? container.decode(UInt64.self) {
+				self.rawValue = idInt;
+			} else {
+				self.rawValue = 0;
+			}
+		}
+	}
 
     /// Initialize from a UInt64
     public init(_ snowflake: UInt64) {

--- a/Sources/Swiftcord/Types/Snowflake.swift
+++ b/Sources/Swiftcord/Types/Snowflake.swift
@@ -36,24 +36,23 @@ public struct Snowflake: Codable {
         return Int((rawValue & 0x3E0000) >> 17)
     }
     
-	
 	/// Need to implement out own decoder, since the Snowflake IDs come in as Strings from the API. Also check for UInt64 just to be complete.
 	/// Sets the rawValue to 0 in the event the string value can't be made into a UInt64.
 	/// - Parameter decoder: The dcoder to decode with.
 	public init(from decoder: Decoder) throws {
 		let container = try decoder.singleValueContainer()
-		
+
 		if let idString = try? container.decode(String.self) {
 			if let intVal = UInt64(idString) {
-				self.rawValue = intVal;
+				self.rawValue = intVal
 			} else {
-				self.rawValue = 0;
+				self.rawValue = 0
 			}
 		} else {
 			if let idInt = try? container.decode(UInt64.self) {
-				self.rawValue = idInt;
+				self.rawValue = idInt
 			} else {
-				self.rawValue = 0;
+				self.rawValue = 0
 			}
 		}
 	}


### PR DESCRIPTION
Adds getApplicationCommands() methods to Swiftcord and Guild, to return an array of ApplicationCommand objects which can be inspected. ApplicationCommand objects aren't meant to be used to make new commands, just see what's currently in the global and guild spaces for a bot.

Also add a parameter to request() and requestWithBodyAsData() and their associated baseRequest...() methods to tell them to return the JSON received from the API as the Data, rather than running it through JSONSerialization and turning it into objects. This is useful for callers who want to just use the straight JSON data to use JSONDecoder to build objects.