### PR TITLE
Add `messageContent` privileged intent

### DIFF
--- a/Sources/Swiftcord/Utils/Enums.swift
+++ b/Sources/Swiftcord/Utils/Enums.swift
@@ -389,6 +389,9 @@ public enum Intents: Int {
 
     /// Typing event of a user in a DM
     case directMessagesTyping = 16384
+    
+    /// Required to receive full content of all messages. This is a privileged intent as of September 2022
+    case messageContent = 32768
 
     /// Events on when an event is created, edited or deleted in a guild
     case guildScheduledEvents = 65536


### PR DESCRIPTION
This new privileged `messageContent` intent is now required for receiving full content of all messages.
Without this, as of September 2022, a bot will receive content of messages only in specific circumstances, such as when you @mention the bot.

For example, without this, if you just write "Hello everybody!" in a guild, a bot will still receive the event with some related info in it, but the event won't contain "Hello everybody!" anywhere in it since this intent is not enabled.

related post: https://support-dev.discord.com/hc/en-us/articles/4404772028055